### PR TITLE
Remove node_modules and package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+dist/
+.env
+*.log


### PR DESCRIPTION
This PR:
1. Adds .gitignore to exclude node_modules and package-lock.json
2. These files will be removed from git tracking as they are generated files that can be recreated using `npm install`

After merging this PR:
1. Delete the local node_modules directory
2. Delete the local package-lock.json file
3. Run `npm install` to recreate these files locally when needed